### PR TITLE
Remove burstable compute skus

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -12,12 +12,12 @@ steps:
 params:
   examples:
     - __name: Development
-      sku_name: B_Standard_B2s
+      sku_name: GP_Standard_D2s_v3
       storage_mb: 32768
       backup_retention_days: 7
       high_availability: false
     - __name: Production
-      sku_name: GP_Standard_D2s_v3
+      sku_name: MO_Standard_E4s_v3
       storage_mb: 262144
       backup_retention_days: 30
       high_availability: true
@@ -55,13 +55,9 @@ params:
           - public
     sku_name:
       title: Compute SKU
-      description: Select the amount of cores, memory, and iops you need for your workload (B = Burstable, D = General Purpose, E = Memory Optimized).
+      description: Select the amount of cores, memory, and iops you need for your workload (D = General Purpose, E = Memory Optimized).
       type: string
       oneOf:
-        - title: B1ms (1 vCore, 2 GiB memory, 640 max iops)
-          const: B_Standard_B1ms
-        - title: B2s (2 vCores, 4 GiB memory, 1280 max iops)
-          const: B_Standard_B2s
         - title: D2s (2 vCores, 8 GiB memory, 3200 max iops)
           const: GP_Standard_D2s_v3
         - title: D4s (4 vCores, 16 GiB memory, 6400 max iops)
@@ -133,8 +129,7 @@ params:
       minimum: 7
       maximum: 35
     high_availability:
-      title: Enable High Availability
-      description: Zone redundant high availability deploys a standby replica to a different zone for automatic failover in the event of an outage. Burstable compute SKUs do not support high availability.
+      title: Enable High Availability (not available for North Central US)
       type: boolean
       default: false
 


### PR DESCRIPTION
Burstable compute tier does not support High Availability. Removing this sku to reduce potential for errors.