### PR TITLE
Use coalesce not try

### DIFF
--- a/src/addons.tf
+++ b/src/addons.tf
@@ -6,8 +6,8 @@ resource "azurerm_postgresql_flexible_server_configuration" "pgbouncer" {
 }
 
 resource "azurerm_postgresql_flexible_server_configuration" "extensions" {
-  count     = length(try(var.addons.extensions, [])) > 0 ? 1 : 0
+  count     = length(coalesce(var.addons.extensions, [])) > 0 ? 1 : 0
   name      = "azure.extensions"
   server_id = azurerm_postgresql_flexible_server.main.id
-  value     = join(",", try(var.addons.extensions, []))
+  value     = join(",", coalesce(var.addons.extensions, []))
 }


### PR DESCRIPTION
This fix failed because `null` is not the same as an error. Coalesce handles `null`.